### PR TITLE
BugFixes & Enhancements to infernal_run script

### DIFF
--- a/src/shell/cmfinder_source_template.sh
+++ b/src/shell/cmfinder_source_template.sh
@@ -5,6 +5,7 @@ export PATH=$PATH:/ysm-gpfs/pi/breaker/software/packages/cmfinder-0.4.1.18/bin
 # Do not modify below this line
 #################################
 SEQDIR=$STEPNAME/$SEQNAME
+if [ -f $SEQDIR/NO_HITS_FOUND ]; then echo "CMfinder did not need to run because prior CMsearch returned no hits."; exit; fi
 BASECOMMAND="cmfinder04.pl -s1 7 -s2 7 -combine -fragmentary -skipClustalw -motifList $SEQDIR/motif.list --allCpus -commaSepEmFlags x--filter-non-frag,--max-degen-per-hit,2,--max-degen-flanking-nucs,7,--degen-keep,--amaa"
 INITIALCOMMAND="$BASECOMMAND $SEQDIR/$SEQNAME.dedupe.fasta"
 REALIGNCOMMAND="$($BASECOMMAND -justGetCmfinderCommand | cut -d':' -f2 | sed 's/\.$//' ) -o $SEQDIR/$SEQNAME.cmfinder.realign.sto -a $SEQDIR/$SEQNAME.cm.align.sto $SEQDIR/$SEQNAME.dedupe.fasta"

--- a/src/shell/infernal_run_template.sh
+++ b/src/shell/infernal_run_template.sh
@@ -17,27 +17,31 @@ infernal_jobfile="$parent_dir/scripts/${STEPNAME}_infernal_jobfile.sh"
 echo "Generating infernal batchfile at $infernal_batchfile"
 dSQ.py --jobfile $infernal_jobfile --batch-file $infernal_batchfile -t 1-0\
   --partition $PARTITION --mem 8G --chdir $parent_dir --status-dir $parent_dir \
-  --output output/infernal_output%4a.out --job-name infernal.$(basename $parent_dir)
+  --output output/infernal_output%4a.out --job-name infernal.$(basename $parent_dir) > /dev/null
 infernal_RESPONSE=$(sbatch $infernal_batchfile)
 infernal_JOBID=${infernal_RESPONSE##* }
+
+# Fix coordinate discrepencies arising from searching a database of IGRs rather than genomes.
+fix_COMMAND=$'#!/bin/bash\n find . -name \*.tblout | xargs -I {} sh -c "../scripts/fix_tblout_coords.sh {} > {}.tmp && mv {}.tmp {}"; find . -name \*.sto | xargs -I {} sh -c "../scripts/fix_sto_coords.sh {} > {}.tmp && mv {}.tmp {}"; find . -name \*.tblout | while read tblout; do if [ `grep -cv "^#" $tblout` -eq 0 ]; then touch `dirname $tblout`/NO_HITS_FOUND; fi; done'
+fix_RESPONSE=$(echo "$fix_COMMAND" | sbatch -p $PARTITION --dependency afterany:${infernal_JOBID} -t 1-0 --job-name fixcoords.$(basename $parent_dir) --chdir $parent_dir/$STEPNAME --output ../output/fixcoords_${STEPNAME}.out)
+fix_JOBID=${fix_RESPONSE##* }
 
 # Fallback option to retry any jobs that fail due to error code 137 out of memory errors
 infernal_bigmem_batchfile="$parent_dir/scripts/${STEPNAME}_infernal_bigmem_batchfile.sh"
 infernal_bigmem_jobfile="$parent_dir/scripts/${STEPNAME}_infernal_bigmem_jobfile.sh"
-infernal_bigmem_dsq="dSQ.py --jobfile $infernal_bigmem_jobfile --batch-file $infernal_bigmem_batchfile \
+infernal_bigmem_dsq="set -x; bigmem_dsq_RESPONSE=\$(dSQ.py --jobfile $infernal_bigmem_jobfile --batch-file $infernal_bigmem_batchfile \
   --partition $PARTITION --mem 32G --chdir $parent_dir --status-dir $parent_dir -c 4 --time 2-0\
-  --output output/infernal_bigmem_output%4a.out --job-name infernal_bigmem.$(basename $parent_dir) --submit"
-bigmem_COMMAND=$'#!/bin/bash \n'"module load dSQ; cat $parent_dir/job_${infernal_JOBID}_status.tsv | cut -f 2,7 | grep ^137 | cut -f2 > $infernal_bigmem_jobfile; $infernal_bigmem_dsq"
-bigmem_RESPONSE=$(echo "$bigmem_COMMAND" | sbatch -p $PARTITION --dependency afterany:${infernal_JOBID} -t 1-0 --job-name dsq_bigmem_infernal.$(basename $parent_dir))
+  --output output/infernal_bigmem_output%4a.out --job-name infernal_bigmem.$(basename $parent_dir) --submit | grep ^Submitted ); \
+  bigmem_dsq_JOBID=\${bigmem_dsq_RESPONSE##* }; \
+  scontrol update job ${fix_JOBID} Dependency=afterany:\${bigmem_dsq_JOBID}"
+bigmem_COMMAND=$'#!/bin/bash \n'"module load dSQ; cat $parent_dir/job_${infernal_JOBID}_status.tsv | cut -f 2,7 | grep ^137 | cut -f2 > $infernal_bigmem_jobfile; if [ -s $infernal_bigmem_jobfile ]; then $infernal_bigmem_dsq; fi"
+bigmem_RESPONSE=$(echo "$bigmem_COMMAND" | sbatch -p $PARTITION --dependency afterany:${infernal_JOBID} -t 1-0 --job-name dsq_bigmem_infernal.$(basename $parent_dir) --output output/dsq_bigmem_output.out)
 bigmem_JOBID=${bigmem_RESPONSE##* }
 
-# Fix coordinate discrepencies arising from searching a database of IGRs rather than genomes.
-fix_COMMAND=$'#!/bin/bash\n find . -name \*.tblout | xargs -I {} sh -c "../scripts/fix_tblout_coords.sh {} > {}.tmp && mv {}.tmp {}"; find . -name \*.sto | xargs -I {} sh -c "../scripts/fix_sto_coords.sh {} > {}.tmp && mv {}.tmp {}"'
-fix_RESPONSE=$(echo "$fix_COMMAND" | sbatch -p $PARTITION --dependency afterany:${bigmem_JOBID} -t 1-0 --job-name fixcoords.$(basename $parent_dir) --chdir $parent_dir/$STEPNAME --output ../output/fixcoords_${STEPNAME}.out)
-fix_JOBID=${fix_RESPONSE##* }
+scontrol update job ${fix_JOBID} Dependency=afterany:${bigmem_JOBID}
 
 # Convert all the results' .sto files into fasta files
-fasta_COMMAND=$'#!/bin/bash\n module load HMMER; find . -type f -name \*.cm.align.sto -ls | awk \'($2>0){print $11}\' | xargs -I{} basename {} .cm.align.sto | xargs -I{} sh -c "esl-reformat fasta {}/{}.cm.align.sto > {}/{}.cmsearch.fasta"'
+fasta_COMMAND=$'#!/bin/bash\n module load HMMER; sleep 20; find . -type f -name \*.cm.align.sto -ls | awk \'($2>0){print $11}\' | xargs -I{} basename {} .cm.align.sto | xargs -I{} sh -c "esl-reformat fasta {}/{}.cm.align.sto > {}/{}.cmsearch.fasta"'
 fasta_RESPONSE=$(echo "$fasta_COMMAND" | sbatch -p $PARTITION --dependency afterany:${fix_JOBID} -t 1-0 --job-name sto2fasta.$(basename $parent_dir) --chdir $parent_dir/$STEPNAME --output ../output/sto2fasta_${STEPNAME}.out)
 fasta_JOBID=${fasta_RESPONSE##* }
 
@@ -53,7 +57,7 @@ echo "Generating cmfinder batchfile at $cmfinder_batchfile"
 dSQ.py --jobfile $cmfinder_jobfile --batch-file $cmfinder_batchfile \
   --partition $PARTITION --mem 16G --chdir $parent_dir --status-dir $parent_dir \
   --output output/cmfinder_output%4a.out --job-name cmfinder.$(basename $parent_dir) \
-  --dependency afterany:${sample_JOBID} --cpus-per-task 2 --time 48:0:0
+  --dependency afterany:${sample_JOBID} --cpus-per-task 2 --time 48:0:0 > /dev/null
 
 cmfinder_RESPONSE=$(sbatch $cmfinder_batchfile)
 cmfinder_JOBID=${cmfinder_RESPONSE##* }


### PR DESCRIPTION
BugFixes:
- Not all IGRs get processed completely:
    Problem: Slow HPC file system.
    Solution: Added "sleep" to delay next job execution.
- Results of bigmem processed IGRs never go through remaining job steps:
    Problem: Fix_coords job step doesn't wait for bigmem job step to complete.
    Solution: Assigned the proper jobID to the Fix_coords dependency setting.
- CMfinder output reports "File Not Found" when trying to process an IGR that had no CMsearch hits:
    Problem: The CMfinder job step blindly processes all IGRs.
    Solution: Flag IGRs that have no hits with a file called "NO_HITS_FOUND".
      Then use this file to conditionally process IGRs with CMfinder.
Enhancements:
- Flag IGRs that have no hits with a visual indicator (a file inside the IGR folder).
  This will aid users during the post-processing audit of results, and reduce "help" calls.
- Removed unnecessary and confusing text generated by dSQ (deadSimpleQueue) that said
  "Use the following sbatch command to submit your job..."
- Set a proper file name for the dsq_bigmem job submittal output and added command logging into it.